### PR TITLE
clean dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,4 @@
-FROM python:3.6.1-alpine
-
-RUN apk add --no-cache --virtual .build-deps gcc musl-dev python3-dev \
-    && pip install cython \
-    && pip install numpy \
-    && apk del .build-deps
-
-RUN apk add --no-cache --update \
-    python3 python3-dev gcc \
-    gfortran musl-dev g++ \
-    libffi-dev openssl-dev \
-    libxml2 libxml2-dev \
-    libxslt libxslt-dev \
-    libjpeg-turbo-dev zlib-dev
+FROM python:3.8.3-slim
 
 RUN pip install --upgrade pip
 

--- a/src/app.py
+++ b/src/app.py
@@ -1,4 +1,3 @@
-import math
 import pgeocode
 import re
 


### PR DESCRIPTION
Take a look a docker file with a Debian layer. It is slim.
I have tested and the image sizes are actually smaller since the alpine needs to have lots more build dependencies.
```
docker-pgeocode_geocode                             debian              15fa601b4b73        16 minutes ago      303MB
docker-pgeocode_geocode                             alpine               28a3c0d25719        5 minutes ago       595MB
```
I think it is a good tradeoff since the building time is really long. It takes 20+ mins to build from scratch, which for a microservice like this is not a big deal.

In a later PR I will add more code to the library to validate inputs.
